### PR TITLE
feat: support custom start/end shortcodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,14 @@ export const parse = (
     ...options,
   };
 
+  // note this will currently break if an attribute value contains an `tagEnd`
+  // TODO is to replace the tokenizer with a more robust solution
+  // for now it is ok
+  const re = new RegExp(`\\${options.tagStart}(\\w+)(\\s+(.*?))?${options.tagEnd}`);
   return tokenize(
     string,
     {
-      shortcode: /\[(\w+)(\s+(.*?))?]/,
+      shortcode: re,
     },
     "text"
   ).map((token) => {

--- a/test/parseShortCodesTest.ts
+++ b/test/parseShortCodesTest.ts
@@ -59,3 +59,17 @@ test("can parse multiple shortcodes with whitespace between", (t) => {
     { type: "shortcode", token: "[test]", name: "test" },
   ]);
 });
+
+test("custom startTag/endTag: can parse multiple shortcodes with whitespace between", (t) => {
+  t.deepEqual(
+    parse("{test a=1 b=2} test {test}", {
+      tagStart: "{",
+      tagEnd: "}",
+    }),
+    [
+      { type: "shortcode", token: "{test a=1 b=2}", name: "test", attributes: { a: 1, b: 2 } },
+      { type: "text", token: " test " },
+      { type: "shortcode", token: "{test}", name: "test" },
+    ]
+  );
+});


### PR DESCRIPTION
default is only `[shortcode]` using brackets

this allows custom start/end tags

i.e.
`{shortcode}`

usage:

````typescript
parse("{test a=1 b=2} test {test}", {
  tagStart: "{",
  tagEnd: "}",
});
````